### PR TITLE
Update Microsoft.Identity.Client ver.4.21.1

### DIFF
--- a/EmbeddedMsalCustomWebUi.Wpf/EmbeddedMsalCustomWebUi.Wpf.csproj
+++ b/EmbeddedMsalCustomWebUi.Wpf/EmbeddedMsalCustomWebUi.Wpf.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.21.1" />
   </ItemGroup>
   
 </Project>

--- a/EmbeddedMsalCustomWebUi.Wpf/Internal/EmbeddedWebUiWindow.xaml.cs
+++ b/EmbeddedMsalCustomWebUi.Wpf/Internal/EmbeddedWebUiWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Identity.Client.Extensibility;
+﻿using Microsoft.Identity.Client;
 using System;
 using System.Linq;
 using System.Threading;
@@ -49,7 +49,7 @@ namespace EmbeddedMsalCustomWebUi.Wpf.Internal
             {
                 // error.
                 _taskCompletionSource.SetException(
-                    new MsalExtensionException(
+                    new MsalException(
                         $"An error occurred, error: {query.Get("error")}, error_description: {query.Get("error_description")}"));
             }
 


### PR DESCRIPTION
## Issue
Fixes #6 

## Detail  
Update Microsoft.Identity.Client 4.11.0->4.21.1
In the latest version,  MsalExtensionException was removed. 
So we change MsalExtensionException to MsalException.

(It is my first contribute. I am sorry if I have some mistakes)